### PR TITLE
Remove TAGE GHR display line

### DIFF
--- a/2bitTest/BranchPrediction_v2.html
+++ b/2bitTest/BranchPrediction_v2.html
@@ -83,7 +83,6 @@
 
     <div id="status-tage" style="display:none">
       <h3>TAGE (longest)</h3>
-      <p>GHR: <span id="ghrDumpTage">0</span></p>
       <table id="tageTbl"><thead><tr><th>Idx</th><th>ctr</th><th>u</th></tr></thead><tbody></tbody></table>
     </div>
 


### PR DESCRIPTION
## Summary
- delete the unused TAGE GHR line from the HTML demo

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683f6f7abe0483328443402bf0f536b0